### PR TITLE
fix p2strings when argument is a string

### DIFF
--- a/ppt2video/src/parse.js
+++ b/ppt2video/src/parse.js
@@ -7,6 +7,10 @@ function p2strings(p){
     return [];
   }
 
+  if (typeof p === 'string'){
+    return [p];
+  }
+
   // empty object -> empty string
   const ret = p.map(s => typeof s === 'string'?s:'');
 


### PR DESCRIPTION
tika の XML出力を xml2js で JavaScript オブジェクトに変換したとき、ページのコンテンツによって以下の 3パターンに変換されるのですが、(2) stringケースに対応できていませんでした。
(1) undefined ケース
<div class="slide-content">
</div>
div: {
  class: "slide-content",
},
(2) string ケース
<div class="slide-content">
  <p>タイトル</p>
</div>
div: {
  class: "slide-content",
  p: "タイトル",
},
(3) string 配列ケース
<div class="slide-content">
  <p>現代社会：VUCA時代</p>
  <p>Volatility：変動性    ･･･技術進化，社会変化</p>
</div>
div: {
  class: "slide-content",
  p: [ '現代社会：VUCA時代', 'Volatility：変動性\t ･･･技術進化，社会変化'],
},
