### PR TITLE
ユーザ操作のログ保存機能の実装

### DIFF
--- a/ppt2video/src/browser.js
+++ b/ppt2video/src/browser.js
@@ -69,9 +69,10 @@ const exports = {
 export async function getPptx(filename) {
   try {
     const buf = await readFile(filename);
+    const pptxSize = buf.byteLength;
     const pptx = await getPptxData(buf);
     const filepath = path.parse(filename);
-    return {...pptx, filepath, ...exports};
+    return {...pptx, pptxSize, filepath, ...exports};
   } catch(e) {
     throw new Error("PPTXファイルのオープンに失敗しました。\n" + e.message);
   }

--- a/ppt2video/src/browser.js
+++ b/ppt2video/src/browser.js
@@ -170,6 +170,7 @@ async function process(options = {}) {
       let data;
       try {
         data = await this.muxTopic(topic, chunks, fps);
+        topic.fileSize = data.byteLength;
       } catch(e){
         throw new Error('can not mux topic.\n' + e.message);
       }
@@ -180,6 +181,7 @@ async function process(options = {}) {
       }
       // update timeRequired in json
       const sum = topic.slides.reduce((acc,slide) => acc + slide.duration,0);
+      topic.duration = sum;
       topic.importJson.timeRequired = sum > 1 ? Math.floor(sum) : 1;
     }
   }

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -4,3 +4,4 @@ dist
 keys/
 .vscode/
 log/
+httplog/

--- a/server/app.js
+++ b/server/app.js
@@ -26,7 +26,7 @@ function pollyErrorHandler (err, req, res, next) {
 
 morgan.token('info', (req, res) => {
   if (!req.locals) return "- -";
-  let {id, user_id, len, message, log} = req.locals;
+  let {id, user_id, len, message, log, mp3size} = req.locals;
 
   // POST /login error
   if (message) return "- error " + message;
@@ -40,7 +40,8 @@ morgan.token('info', (req, res) => {
 
   // POST /app/polly
   if (!len) len = 0;
-  return `${id} ${len}`;
+  if (!mp3size) mp3size = 0;
+  return `${id} ${len} ${mp3size}`;
 });
 
 morgan.token('iso8601local', (req, res) => {

--- a/server/app.js
+++ b/server/app.js
@@ -3,6 +3,7 @@ import path from 'path';
 import cookieParser from 'cookie-parser';
 import morgan from 'morgan';
 import { fileURLToPath } from "url";
+import moment from 'moment';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -33,7 +34,11 @@ morgan.token('info', (req, res) => {
   return `${id} ${len}`;
 });
 
-app.use(morgan(':remote-addr :req[x-forwarded-for] :method :url :status :info'));
+morgan.token('iso8601local', (req, res) => {
+  return moment().toISOString(true);
+})
+
+app.use(morgan(':iso8601local :remote-addr :req[x-forwarded-for] :method :url :status :info'));
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));

--- a/server/app.js
+++ b/server/app.js
@@ -26,10 +26,19 @@ function pollyErrorHandler (err, req, res, next) {
 
 morgan.token('info', (req, res) => {
   if (!req.locals) return "- -";
-  let {id, user_id, len, message} = req.locals;
-  if (message) return "- " + message;
+  let {id, user_id, len, message, log} = req.locals;
+
+  // POST /login error
+  if (message) return "- error " + message;
+
+  // POST /login
   if (!id) id = "-";
   if (user_id) return `${id} ${user_id}`;
+
+  // POST /log
+  if (log) return `${id} ` + log.join(' ');
+
+  // POST /app/polly
   if (!len) len = 0;
   return `${id} ${len}`;
 });

--- a/server/config.js
+++ b/server/config.js
@@ -9,6 +9,8 @@ const config = {
   logdir: process.env.POLLY_LOGDIR || "log",
   wasm: (process.env.POLLY_WASM === "true") || false,
   appStartUrl: process.env.POLLY_APP_START_URL || 'https://localhost:3006/dialog/start',
+  httplogdir: process.env.POLLY_HTTPLOGDIR || "httplog",
+  teeToStdout: (process.env.POLLY_TEETOSTDOUT === "true") || false,
 };
 
 export default config;

--- a/server/package.json
+++ b/server/package.json
@@ -23,6 +23,7 @@
     "express": "^4.18.2",
     "express-bearer-token": "^2.4.0",
     "jsonwebtoken": "^9.0.0",
+    "moment": "^2.30.1",
     "morgan": "^1.10.0",
     "nanoid": "^4.0.2"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,8 @@
     "jsonwebtoken": "^9.0.0",
     "moment": "^2.30.1",
     "morgan": "^1.10.0",
-    "nanoid": "^4.0.2"
+    "nanoid": "^4.0.2",
+    "rotating-file-stream": "^3.2.6"
   },
   "devDependencies": {
     "cpx2": "^4.2.3",

--- a/server/routes/log.js
+++ b/server/routes/log.js
@@ -10,7 +10,35 @@ router.options("*", cors());
 
 router.post("/", cors(), async function (req, res, next) {
   try {
-    console.log(req.body);
+    const { type, filename, size, numslides, numtopics, duration, message } = req.body;
+    const log = [type];
+    req.locals.log = log;
+    switch(type) {
+    case 'open-directory':
+      break;
+    case 'open-pptx':
+      log[1] = filename;
+      log[2] = size;
+      log[3] = numslides;
+      break;
+    case 'output-video':
+      log[1] = filename;
+      log[2] = numtopics;
+      break;
+    case 'save-video':
+      log[1] = filename;
+      log[2] = size;
+      log[3] = duration;
+      break;
+    case 'error':
+      log[1] = message;
+      break;
+    default:
+      log[0] = 'error';
+      log[1] = 'type unknown';
+      res.status(400).send(log[1]);
+      return;
+    }
     res.send('OK');
   } catch (error) {
     next(error);

--- a/server/routes/log.js
+++ b/server/routes/log.js
@@ -1,0 +1,20 @@
+import express from "express";
+import cors from "cors";
+const router = express.Router();
+
+import { bearer, check } from './login.js';
+router.use(bearer, check);
+
+// allow CORS with all pre-flight request and POST /log request
+router.options("*", cors());
+
+router.post("/", cors(), async function (req, res, next) {
+  try {
+    console.log(req.body);
+    res.send('OK');
+  } catch (error) {
+    next(error);
+  }
+});
+
+export { router };

--- a/server/routes/log.js
+++ b/server/routes/log.js
@@ -10,7 +10,15 @@ router.options("*", cors());
 
 router.post("/", cors(), async function (req, res, next) {
   try {
-    const { type, filename, size, numslides, numtopics, duration, message } = req.body;
+    const {
+      type,
+      filename = '-',
+      size = 0,
+      numslides = 0,
+      numtopics = 0,
+      duration = 0,
+      message = '-',
+    } = req.body;
     const log = [type];
     req.locals.log = log;
     switch(type) {

--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -15,7 +15,16 @@ const option = {
   expiresIn: "7d",
 };
 
-router.post('/', function(req, res, next) {
+async function anonymize(user_id) {
+  const s = user_id.split('@');
+  if (s[0].length > 0) {
+    const h = await crypto.subtle.digest('sha-256', new ArrayBuffer(s[0]));
+    s[0] = btoa(h);
+  }
+  return s.join('@');
+}
+
+router.post('/', async function(req, res, next) {
   const {user_id, password} = req.body;
   if (password === cPassword) {
     const id = nanoid();
@@ -27,7 +36,8 @@ router.post('/', function(req, res, next) {
       secure: false,
       httpOnly: false,
     });
-    req.locals = {id, user_id};
+    const au = await anonymize(user_id);
+    req.locals = {id, user_id: au};
     res.send('OK');
   } else {
     res.status(401).send('unauthorized');

--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -37,11 +37,7 @@ router.post('/', function(req, res, next) {
 function check(req, res, next) {
   if (!config.authorization) {
     req.locals = {id: '-', len: 0};
-    if (req.body.Text) {
-      next();
-    } else {
-      res.send('noauthorize');
-    }
+    next();
     return;
   }
 
@@ -55,20 +51,36 @@ function check(req, res, next) {
       req.locals = {id: decoded.sub, len: 0};
     }
     if (req.locals) {
-      if (req.body.Text) {
-        next();
-      } else {
-        res.send('authorized');
-      }
+      next();
       return;
     }
+    req.locals = {message: 'token not found'};
   } catch (err) {
     req.locals = {message: err.message};
   }
   res.status(401).send('unauthorized');
 }
 
+function auth(req, res, next) {
+  const result = config.authorization?'authorized':'noauthorize';
+  if (req.body.Text) {
+    next();
+    return;
+  } else {
+    res.send(result);
+  }
+}
+
+import bearerToken from 'express-bearer-token';
+const bearer = bearerToken({
+  cookie: {
+    key: 'session_cookie'
+  }
+});
+
 export {
   router,
   check,
+  auth,
+  bearer,
 };

--- a/server/routes/polly.js
+++ b/server/routes/polly.js
@@ -45,8 +45,9 @@ router.post("/", cors(), async function (req, res, next) {
     const data = await SynthesizeSpeech(req.body);
     res.setHeader("content-type", data.ContentType);
     const len = data.RequestCharacters;
-    req.locals.len = len;
     if (config.authorization) access.processed(len);
+    req.locals.len = len;
+    req.locals.mp3size = data.AudioStream.length;
     res.send(data.AudioStream);
   } catch (error) {
     error.statusCode = error.$metadata.httpStatusCode;

--- a/server/routes/polly.js
+++ b/server/routes/polly.js
@@ -2,15 +2,8 @@ import express from "express";
 import cors from "cors";
 const router = express.Router();
 
-import bearerToken from 'express-bearer-token';
-router.use(bearerToken({
-  cookie: {
-    key: 'session_cookie'
-  }
-}));
-
-import { check } from './login.js';
-router.use(check);
+import { bearer, check, auth } from './login.js';
+router.use(bearer, check, auth);
 
 import { PollyClient, SynthesizeSpeechCommand } from '@aws-sdk/client-polly';
 import config from '../config.js';

--- a/server/routes/wasm.js
+++ b/server/routes/wasm.js
@@ -4,6 +4,7 @@
 
 import express from "express";
 import { router as pollyRouter } from './polly.js';
+import { router as logRouter } from './log.js';
 const router = express.Router();
 
 import config from '../config.js';
@@ -21,5 +22,6 @@ router.use(function (req, res, next) {
 });
 
 router.use('/polly', pollyRouter);
+router.use('/log', logRouter);
 
 export { router };

--- a/wasm-app/pages/index.js
+++ b/wasm-app/pages/index.js
@@ -238,8 +238,10 @@ function App() {
       setError1(null);
       await openDirectory();
       readDirectory();
+      await submitLog({type: 'open-directory'});
     } catch(e) {
       setError1('ディレクトリを開くことができませんでした。\n' + e.message);
+      await submitLog({type: 'error', message: 'open-directory'});
     }
   }
 
@@ -272,11 +274,13 @@ function App() {
     try {
       setError2(null);
       await readPptx();
+      await submitLog({type: 'open-pptx', filename});
       setStep(steps.step3);
       chengeStep(2);
     } catch(e) {
       setError2(e.toString());
       setStep(steps.step3);
+      await submitLog({type: 'error', message: 'open-pptx'});
     }
   }
 
@@ -338,11 +342,13 @@ function App() {
       }
       finalTopicList(timerId);
       await processImportJson(topicCheckList);
+      await submitLog({type: 'output-video', filename, numtopics: numTopics});
       setStep(steps.step4);
     } catch(e){
       finalTopicList(timerId);
       setError3(e.message);
       setStep(steps.step3);
+      await submitLog({type: 'error', message: 'output-video'});
     }
   }
 
@@ -363,12 +369,14 @@ function App() {
     try {
       setError4(null);
       await flushZip();
+      await submitLog({type: 'save-video', filename});
       setPptxList([]);
       setFilename(null);
       setTopicList([]);
       readDirectory();
     } catch(e){
       setError4('zipファイルの保存に失敗しました。\n' + e.message);
+      await submitLog({type: 'error', message: 'save-video'});
     }
   }
 

--- a/wasm-app/pages/index.js
+++ b/wasm-app/pages/index.js
@@ -198,6 +198,11 @@ function getStatistics() {
   return {size: totalFileSize, duration: totalDuration};
 }
 
+async function anonymize(s) {
+  const h = await crypto.subtle.digest('sha-256', new ArrayBuffer(s));
+  return btoa(h);
+}
+
 function App() {
   const [step, setStep] = useState(steps.step1);
   const [pptxList, setPptxList] = useState([]);
@@ -285,7 +290,8 @@ function App() {
     try {
       setError2(null);
       await readPptx();
-      await submitLog({type: 'open-pptx', filename, size: pptx.pptxSize, numslides: pptx.numSlides});
+      const filename_hash = await anonymize(filename);
+      await submitLog({type: 'open-pptx', filename: filename_hash, size: pptx.pptxSize, numslides: pptx.numSlides});
       setStep(steps.step3);
       chengeStep(2);
     } catch(e) {
@@ -353,7 +359,8 @@ function App() {
       }
       finalTopicList(timerId);
       await processImportJson(topicCheckList);
-      await submitLog({type: 'output-video', filename, numtopics: numTopics});
+      const filename_hash = await anonymize(filename);
+      await submitLog({type: 'output-video', filename: filename_hash, numtopics: numTopics});
       setStep(steps.step4);
     } catch(e){
       finalTopicList(timerId);
@@ -380,7 +387,8 @@ function App() {
     try {
       setError4(null);
       await flushZip();
-      await submitLog({type: 'save-video', filename, ...getStatistics()});
+      const filename_hash = await anonymize(filename);
+      await submitLog({type: 'save-video', filename: filename_hash, ...getStatistics()});
       setPptxList([]);
       setFilename(null);
       setTopicList([]);

--- a/wasm-app/pages/index.js
+++ b/wasm-app/pages/index.js
@@ -187,6 +187,17 @@ async function processAuthorized() {
   return await pptx.process({authorized: true});
 }
 
+function getStatistics() {
+  let totalFileSize = 0;
+  let totalDuration = 0;
+  for (const section of pptx.sections) {
+    const {fileSize, duration} = section.topics[0];
+    if (fileSize) totalFileSize += fileSize;
+    if (duration) totalDuration += duration;
+  }
+  return {size: totalFileSize, duration: totalDuration};
+}
+
 function App() {
   const [step, setStep] = useState(steps.step1);
   const [pptxList, setPptxList] = useState([]);
@@ -274,7 +285,7 @@ function App() {
     try {
       setError2(null);
       await readPptx();
-      await submitLog({type: 'open-pptx', filename});
+      await submitLog({type: 'open-pptx', filename, size: pptx.pptxSize, numslides: pptx.numSlides});
       setStep(steps.step3);
       chengeStep(2);
     } catch(e) {
@@ -369,7 +380,7 @@ function App() {
     try {
       setError4(null);
       await flushZip();
-      await submitLog({type: 'save-video', filename});
+      await submitLog({type: 'save-video', filename, ...getStatistics()});
       setPptxList([]);
       setFilename(null);
       setTopicList([]);


### PR DESCRIPTION
WASM版のユーザ操作を、server のログに保存する機能の実装です。
以下の作業が完了したら main にマージします。

- [x] wasm-app: ユーザ操作の記録
- [x] wasm-app: open-pptx, save-video のパラメータ対応
- [x] wasm-app: ファイル名を匿名化する

- [x] server: ログ記録API
- [x] server: ログにISO8601 JSTで時刻を記録する
- [x] server: POST /app/polly で、末尾に音声データサイズを表示する
- [x] server: ユーザ名を匿名化する
- [x] server: 日次ファイルに出力する
