### PR TITLE
fix: ハッシュ化したデータが同じ値になる

### DIFF
--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -18,8 +18,8 @@ const option = {
 async function anonymize(user_id) {
   const s = user_id.split('@');
   if (s[0].length > 0) {
-    const h = await crypto.subtle.digest('sha-256', new ArrayBuffer(s[0]));
-    s[0] = btoa(h);
+    const h = await crypto.subtle.digest('sha-256', new TextEncoder().encode(s[0]));
+    s[0] = btoa(String.fromCharCode.apply(null, new Uint8Array(h)));
   }
   return s.join('@');
 }

--- a/wasm-app/pages/index.js
+++ b/wasm-app/pages/index.js
@@ -199,8 +199,8 @@ function getStatistics() {
 }
 
 async function anonymize(s) {
-  const h = await crypto.subtle.digest('sha-256', new ArrayBuffer(s));
-  return btoa(h);
+  const h = await crypto.subtle.digest('sha-256', new TextEncoder().encode(s));
+  return btoa(String.fromCharCode.apply(null, new Uint8Array(h)));
 }
 
 function App() {


### PR DESCRIPTION
ハッシュ化したデータが、常に W29iamVjdCBBcnJheUJ1ZmZlcl0= になる問題を修正しました。

問題は 2つありました。
- 対象の文字列を ArrayBuffer に変更する方法を間違えていた
- digest で得られた 32バイトの ArrayBuffer をそのまま btoa に渡していた

変更したファイルは、次の 2 つです。
- server/routes/login.js
- wasm-app/index.js

wasm-app を変更しているので、次の作業が必要です。
```
cd wasm-app
yarn build
cd server
npm run copy:app
```

ハッシュ化したデータが正しいかどうか、以下のような Linux コマンドラインで得られる文字列と比較してください。
```
echo -n 'vuca.pptx' | sha256sum | xxd -r -p | base64
```
