### PR TITLE
ログ集計スクリプトで開始日、終了日をCSVに出力する

### DIFF
--- a/server/aggregate.js
+++ b/server/aggregate.js
@@ -3,6 +3,7 @@ import process from 'node:process'
 
 let in_range;
 let files;
+let start_end;
 
 //
 // 集計
@@ -187,11 +188,11 @@ function check_active() {
 //
 
 function write_header() {
-  console.log('category,open-directory,open-pptx,output-video,save-video,polly-num,polly-chars,user-num,login-num');
+  console.log('start,end,category,open-directory,open-pptx,output-video,save-video,polly-num,polly-chars,user-num,login-num');
 }
 
 function write_array(ar) {
-  console.log(ar.join(','));
+  console.log(start_end + ar.join(','));
 }
 
 function write_dict(dict) {
@@ -223,12 +224,14 @@ function parse_args() {
       return words[0].startsWith(process.argv[2]);
     };
     files = process.argv.slice(3);
+    start_end = process.argv[2] + ',,';
   } else if (process.argv[2].length == 10) {
     in_range = (words) => {
       const date = words[0].slice(0,10);
       return process.argv[2] <= date && date <= process.argv[3];
     };
     files = process.argv.slice(4);
+    start_end = process.argv[2] + ',' + process.argv[3] + ',';
   }
 }
 

--- a/server/agwin.js
+++ b/server/agwin.js
@@ -15,7 +15,7 @@ function print_days() {
     const cur_str = cur.toISOString().slice(0,10);
     const end_str = (cend <= end ?cend:end).toISOString().slice(0,10);
 
-    console.log('node aggregate.js', cur_str, end_str, params.join(' '), '>', cur_str + '_' + end_str + '.txt');
+    console.log('node aggregate.js', cur_str, end_str, params.join(' '));
 
     cur.setUTCDate(cur.getUTCDate() + days);
   }


### PR DESCRIPTION
CSVファイルの各行の先頭に、集計開始日と終了日を出力するように変更します。

agwin.js はファイルへのリダイレクトを行わないようにしました。各行に集計期間が出力されているので、複数回 aggregate.js を動作させた結果を1つのファイルにまとめて保存することが可能です。

```
$ node aggregate.js 2025-03-01 2025-03-31 httplog/202503*
start,end,category,open-directory,open-pptx,output-video,save-video,polly-num,polly-chars,user-num,login-num
2025-03-01,2025-03-31,acutus,1,1,1,1,6,124,1,1
2025-03-01,2025-03-31,b8sKPjKLZKr8nMQiavxS1rf3uqHb/9Jo1KeGnUSMfmk=@acutus,1,1,1,1,6,124,0,0
2025-03-01,2025-03-31,error,0,0,0,0,0,0,0,0

$ node agwin.js 2025-03-01 2025-03-31 7
node aggregate.js 2025-03-01 2025-03-07
node aggregate.js 2025-03-08 2025-03-14
node aggregate.js 2025-03-15 2025-03-21
node aggregate.js 2025-03-22 2025-03-28
node aggregate.js 2025-03-29 2025-03-31
```