### PR TITLE
LFとCRLFの両方の改行に対応

### DIFF
--- a/ppt2video/src/pptx.js
+++ b/ppt2video/src/pptx.js
@@ -56,7 +56,7 @@ function extractLine(chunks) {
   for (const chunk of chunks) {
     ret.push(chunk['a:t']);
   }
-  return ret.join('').split('\r\n');
+  return ret.join('').split(/\r?\n/);
 }
 
 function block2lines(block) {
@@ -135,7 +135,7 @@ function getTextXpath(dom, type){
       }
     }
     if (node.parentNode.parentNode.parentNode.nodeName !== "mc:Fallback") {
-      ret.push(line.join('').split('\r\n'));
+      ret.push(line.join('').split(/\r?\n/));
     }
     node = lines.iterateNext();
   }


### PR DESCRIPTION
fix #68
extractLine と getTextXpath の行分割処理を正規表現で書き直して、'\n' と '\r\n' どちらの改行形式でも正しく動くようにした。